### PR TITLE
Fix swshop breaking with other websockets

### DIFF
--- a/swshop/w.lua
+++ b/swshop/w.lua
@@ -71,14 +71,14 @@ function init(jua)
 	jua = jua
 	if async then
 		jua.on("websocket_success", function(event, url, handle)
-			local id = findID(url)
+			local success, id = pcall(findID,url)
 			if id and callbackRegistry[id] and callbackRegistry[id].success then
 				callbackRegistry[id].success(id, handle)
 			end
 		end)
 
 		jua.on("websocket_failure", function(event, url)
-			local id = findID(url)
+			local success, id = pcall(findID,url)
 			if id and callbackRegistry[id] and callbackRegistry[id].failure then
 				callbackRegistry[id].failure(id)
 			end
@@ -86,14 +86,14 @@ function init(jua)
 		end)
 
 		jua.on("websocket_message", function(event, url, data)
-			local id = findID(url)
+			local success, id = pcall(findID,url)
 			if id and callbackRegistry[id] and callbackRegistry[id].message then
 				callbackRegistry[id].message(id, data)
 			end
 		end)
 
 		jua.on("websocket_closed", function(event, url)
-			local id = findID(url)
+			local success, id = pcall(findID,url)
 			if id and callbackRegistry[id] and callbackRegistry[id].closed then
 				callbackRegistry[id].closed(id)
 			end


### PR DESCRIPTION
w.lua does not like websockets not opened with w.lua. This fixes that. This should fix not being able to use cloudcatcher/chatbox and operate the shop at the same time. Also, I know that just doing a pcall seems like a hacky thing to do but I tried editing the findid function and it wouldn't work. 