### PR TITLE
fix milo setup crash

### DIFF
--- a/milo/core/machines.lua
+++ b/milo/core/machines.lua
@@ -143,7 +143,7 @@ function networkPage:applyFilter()
 		return v.mtype ~= 'hidden'
 	end)
 
-	if #self.filter.value > 0 then
+	if self.filter.value and #self.filter.value > 0 then
 		local filter = self.filter.value:lower()
 		t = Util.filter(t, function(v)
 			return v.displayName and


### PR DESCRIPTION
I've applied to this to my milo because I thought it was a one-off thing, however when setting up a new milo turtle I noticed that the crash also happened, so this fixes it. also the new textentry behavior should probably be reverted instead of doing this,