### PR TITLE
Temporary patch for #20

### DIFF
--- a/swshop/shopTab.lua
+++ b/swshop/shopTab.lua
@@ -25,7 +25,7 @@ local shopTab = UI.Tab {
 			formLabel = 'Price', formKey = 'price',
 			help = 'Per item cost',
 			required = true,
-			transform = 'number',
+			validate = 'numeric',
 		},
 		[3] = UI.TextEntry {
 			limit = 64,


### PR DESCRIPTION
This temporarily reverts the change to the price field in swshop's Store tab from 64ec8c82d301639bc397aafe69dd74974b8161ca. 

The problem, as you probably know, is in TextEntry in opus:
https://github.com/kepler155c/opus/blob/cef5b21921705736249428274d12062b982c0bbc/sys/modules/opus/ui/components/TextEntry.lua#L108-L117

The transform function is ran every time a character is typed, which results in decimal values like `0.05` being transformed to `5`, as it's typed like this:

| Input | Transformed |
|-------|-------------|
| 0     | 0           |
| 0.    | 0           |
| 0.0   | 0           |
| 0.05  | 5 (05)      |

Really, a proper transformer for decimal numbers should be implemented, but for now, this gets shops working again.