### PR TITLE
Add a Defragment button to Milo

### DIFF
--- a/milo/apis/storage.lua
+++ b/milo/apis/storage.lua
@@ -336,6 +336,7 @@ end
 -- defrags the storage system
 function Storage:defrag(throttle)
 	local items = self:listProviders(throttle)
+	local slotsSaved = 0
 
 	for _, providers in pairs(items) do
 		table.sort(providers, function(a, b)
@@ -368,6 +369,7 @@ function Storage:defrag(throttle)
 
 			if from.item.count <= 0 then
 				table.remove(providers, 1)
+				slotsSaved = slotsSaved + 1
 			end
 
 			table.sort(providers, function(a, b)
@@ -375,6 +377,8 @@ function Storage:defrag(throttle)
 			end)
 		end
 	end
+
+	return slotsSaved
 end
 
 function Storage:updateCache(adapter, item, count)

--- a/milo/apis/storage.lua
+++ b/milo/apis/storage.lua
@@ -293,30 +293,33 @@ end
 
 -- provide a raw list of all the items in all storage chests
 -- it might be beneficial to move this to the adapter class at some point and cache the raw item list in this class at some point
-function Storage:listItemsRaw()
+function Storage:listItemsRaw(throttle)
 	local res = {}
 
-  for _, v in pairs(self.nodes) do
-    if v.category == "storage" then
-      local chest = device[v.name]
+	throttle = throttle or Util.throttle()
+
+	for _, v in pairs(self.nodes) do
+		if v.category == "storage" then
+			local chest = device[v.name]
 			local items = chest.list()
 
 			for slot, item in pairs(items) do
 				items[slot] = itemDB:get(item, function() return chest.getItemMeta(slot) end)
 			end
 
-      res[v.name] = items
-    end
-  end
+			res[v.name] = items
+			throttle()
+		end
+	end
 
-  return res
+	return res
 end
 
 -- provide a list of items and which chests provide them
-function Storage:listProviders()
+function Storage:listProviders(throttle)
 	local res = {}
 
-	local rawItems = self:listItemsRaw()
+	local rawItems = self:listItemsRaw(throttle)
 
 	for chest, items in pairs(rawItems) do
 		for slot, item in pairs(items) do
@@ -331,8 +334,8 @@ function Storage:listProviders()
 end
 
 -- defrags the storage system
-function Storage:defrag()
-	local items = self:listProviders()
+function Storage:defrag(throttle)
+	local items = self:listProviders(throttle)
 
 	for _, providers in pairs(items) do
 		table.sort(providers, function(a, b)

--- a/milo/apis/storage.lua
+++ b/milo/apis/storage.lua
@@ -374,9 +374,9 @@ function Storage:defrag(throttle)
 			-- are ruled out by the condition of the outer while loop
 			for i = 2, #providers do
 				-- Give preference to locked chests
-				if not to.lockedToThis and providers[i].lockedToThis then
+				if not (to and to.lockedToThis or false) and providers[i].lockedToThis then
 					to = providers[i]
-				elseif (to.lockedToThis == providers[i].lockedToThis) and providers[i].item.count < providers[i].item.maxCount then
+				elseif ((to and to.lockedToThis or false) == providers[i].lockedToThis) and providers[i].item.count < providers[i].item.maxCount then
 					to = providers[i]
 				elseif providers[i].item.count == providers[i].item.maxCount then
 					-- As this slot is already at maxCount, all the remaining ones will also be due to sorting

--- a/milo/apis/storage.lua
+++ b/milo/apis/storage.lua
@@ -327,7 +327,7 @@ function Storage:listProviders(throttle)
 			if not res[key] then
 				res[key] = {}
 			end
-			table.insert(res[key], {item = item, device = device[chest], lockedToThis = Util.contains(Util.keys(self.nodes[chest].lock or {}), key) and true or false, slot = slot})
+			table.insert(res[key], {item = item, device = device[chest], lockedToThis = (self.nodes[chest].lock or {})[key] or false, slot = slot})
 		end
 	end
 	return res

--- a/milo/apis/storage.lua
+++ b/milo/apis/storage.lua
@@ -378,7 +378,7 @@ function Storage:defrag(throttle)
 					to = providers[i]
 				elseif (to.lockedToThis == providers[i].lockedToThis) and providers[i].item.count < providers[i].item.maxCount then
 					to = providers[i]
-				else
+				elseif providers[i].item.count == providers[i].item.maxCount then
 					-- As this slot is already at maxCount, all the remaining ones will also be due to sorting
 					-- If any of the remaining providers is locked that doesn't matter. We wouldn't have been able to push there anyways
 					break

--- a/milo/apis/storage.lua
+++ b/milo/apis/storage.lua
@@ -327,7 +327,7 @@ function Storage:listProviders(throttle)
 			if not res[key] then
 				res[key] = {}
 			end
-			table.insert(res[key], {item = item, device = device[chest], slot = slot})
+			table.insert(res[key], {item = item, device = device[chest], lockedToThis = Util.contains(Util.keys(self.nodes[chest].lock or {}), key) and true or false, slot = slot})
 		end
 	end
 	return res
@@ -338,10 +338,29 @@ function Storage:defrag(throttle)
 	local items = self:listProviders(throttle)
 	local slotsSaved = 0
 
-	for _, providers in pairs(items) do
-		table.sort(providers, function(a, b)
+	-- This will make sure the table is sorted in the following order:
+	-- Unlocked stacks with less than maxCount items | Locked stacks with less than maxCount items | stacks with more than maxCount items
+	-- This way the locked stacks will be filled first
+	local function sortFunction(a, b)
+		local preferenceA, preferenceB
+		preferenceA = (a.item.count == a.item.maxCount and 3)
+									or (a.lockedToThis and 2)
+									or 1
+		preferenceB = (b.item.count == b.item.maxCount and 3)
+									or (b.lockedToThis and 2)
+									or 1
+
+		if preferenceA < preferenceB then
+			return true
+		elseif preferenceB > preferenceA then
+			return false
+		else
 			return a.item.count < b.item.count
-		end)
+		end
+	end
+
+	for _, providers in pairs(items) do
+		table.sort(providers, sortFunction)
 
 		-- We're done when we either compressed the stacks so far, that there's only one left (#providers == 1)
 		-- Or when we've compressed so far, that the there's only one stack which has a lower count than the maxCount
@@ -354,10 +373,14 @@ function Storage:defrag(throttle)
 			-- This loop is guarenteed to assign a value to "to", as the only cases where it wouldn't (#providers == 1 or no provider with less than maxCount)
 			-- are ruled out by the condition of the outer while loop
 			for i = 2, #providers do
-				if providers[i].item.count < providers[i].item.maxCount then
+				-- Give preference to locked chests
+				if not to.lockedToThis and providers[i].lockedToThis then
+					to = providers[i]
+				elseif (to.lockedToThis == providers[i].lockedToThis) and providers[i].item.count < providers[i].item.maxCount then
 					to = providers[i]
 				else
 					-- As this slot is already at maxCount, all the remaining ones will also be due to sorting
+					-- If any of the remaining providers is locked that doesn't matter. We wouldn't have been able to push there anyways
 					break
 				end
 			end
@@ -389,9 +412,7 @@ function Storage:defrag(throttle)
 				slotsSaved = slotsSaved + 1
 			end
 
-			table.sort(providers, function(a, b)
-				return a.item.count < b.item.count
-			end)
+			table.sort(providers, sortFunction)
 		end
 	end
 

--- a/milo/core/listing.lua
+++ b/milo/core/listing.lua
@@ -256,7 +256,8 @@ function page:eventHandler(event)
 		self:setFocus(self.statusBar.filter)
 
 	elseif event.type == 'defrag' then
-		context.storage:defrag()
+		self:defrag()
+		self:refresh(true)
 
 	elseif event.type == 'toggle_display' then
 		displayMode = (displayMode + 1) % 2
@@ -362,6 +363,14 @@ function page:refresh(force)
 	self.throttle:enable()
 	self.allItems = Milo:mergeResources(Milo:listItems(force, throttle))
 	self:applyFilter()
+	self.throttle:disable()
+end
+
+function page:defrag()
+	local throttle = function() self.throttle:update() end
+
+	self.throttle:enable()
+	context.storage:defrag(throttle)
 	self.throttle:disable()
 end
 

--- a/milo/core/listing.lua
+++ b/milo/core/listing.lua
@@ -370,8 +370,9 @@ function page:defrag()
 	local throttle = function() self.throttle:update() end
 
 	self.throttle:enable()
-	context.storage:defrag(throttle)
+	local saved = context.storage:defrag(throttle)
 	self.throttle:disable()
+	self:notifyInfo(("Saved %d slots"):format(saved))
 end
 
 function page:applyFilter()

--- a/milo/core/listing.lua
+++ b/milo/core/listing.lua
@@ -33,6 +33,11 @@ local page = UI.Page {
 						event = 'rescan',
 						help = 'Rescan all inventories'
 					},
+					{
+						text = 'Defragment storage',
+						event = 'defrag',
+						help = 'Defragments the storage'
+					}
 				},
 			},
 		},
@@ -249,6 +254,9 @@ function page:eventHandler(event)
 		self:refresh(true)
 		self.grid:draw()
 		self:setFocus(self.statusBar.filter)
+
+	elseif event.type == 'defrag' then
+		context.storage:defrag()
 
 	elseif event.type == 'toggle_display' then
 		displayMode = (displayMode + 1) % 2


### PR DESCRIPTION
This adds a defragment feature to Milo. It checks for fragmented item stacks. E.g. 2 stacks of 32 Cobblestone will be combined into 1 stack of 64 cobblestone, therefore freeing an item slot for Milo.