### PR TITLE
Add furniController.lua

### DIFF
--- a/milo/plugins/exportTask.lua
+++ b/milo/plugins/exportTask.lua
@@ -69,10 +69,25 @@ function ExportTask:cycle(context)
 					for key in pairs(entry.filter) do
 						local items = Milo:getMatches(itemDB:splitKey(key), entry)
 						for _,item in pairs(items) do
-							if node.adapter.size() ~= Util.size(node.adapter.list()) and context.storage:export(node, nil, item.count, item) == 0 then
-								-- TODO: really shouldn't break here as there may be room in other slots (probably not)
-								-- leaving for now for performance reasons
-								break
+							node.cacheList = node.adapter.list()
+							if node.adapter.size() ~= Util.size(node.cacheList) then
+								-- Here we have a storage which has at least 1 unpopulated slot, we can fire'n'forget into this
+								if context.storage:export(node, nil, item.count, item) == 0 then
+									-- TODO: really shouldn't break here as there may be room in other slots
+									-- leaving for now for performance reasons
+									break
+								end
+							else
+								-- Here we have a storage with all slots occupied, sort through and find open spaces
+								for iNum,_ in ipairs(node.cacheList) do
+									local slot = node.adapter.getItemMeta(iNum)
+									if (slot.name == filterItem.name and slot.count ~= slot.maxCount and
+									(entry.ignoreDamage or slot.damage == filterItem.damage) and
+									(entry.ignoreNbtHash or slot.nbtHash == filterItem.nbtHash)) then
+										-- We found a slot that matches, and is not full, let's export to it!
+										context.storage:export(node, iNum, slot.maxCount - slot.count, item)
+									end
+								end
 							end
 						end
 					end

--- a/milo/plugins/exportTask.lua
+++ b/milo/plugins/exportTask.lua
@@ -66,10 +66,10 @@ function ExportTask:cycle(context)
 				end
 
 				local function exportItems()
+					node.cacheList = node.adapter.list()
 					for key in pairs(entry.filter) do
 						local items = Milo:getMatches(itemDB:splitKey(key), entry)
 						for _,item in pairs(items) do
-							node.cacheList = node.adapter.list()
 							if node.adapter.size() ~= Util.size(node.cacheList) then
 								-- Here we have a storage which has at least 1 unpopulated slot, we can fire'n'forget into this
 								if context.storage:export(node, nil, item.count, item) == 0 then
@@ -91,6 +91,7 @@ function ExportTask:cycle(context)
 							end
 						end
 					end
+					node.cacheList=nil
 				end
 				if type(entry.slot) == 'number' then
 					exportSingleSlot()

--- a/milo/plugins/exportTask.lua
+++ b/milo/plugins/exportTask.lua
@@ -69,8 +69,8 @@ function ExportTask:cycle(context)
 					for key in pairs(entry.filter) do
 						local items = Milo:getMatches(itemDB:splitKey(key), entry)
 						for _,item in pairs(items) do
-							if context.storage:export(node, nil, item.count, item) == 0 then
-								-- TODO: really shouldn't break here as there may be room in other slots
+							if node.adapter.size() ~= Util.size(node.adapter.list()) and context.storage:export(node, nil, item.count, item) == 0 then
+								-- TODO: really shouldn't break here as there may be room in other slots (probably not)
 								-- leaving for now for performance reasons
 								break
 							end

--- a/milo/plugins/exportTask.lua
+++ b/milo/plugins/exportTask.lua
@@ -1,6 +1,7 @@
 local itemDB = require('core.itemDB')
 local Milo   = require('milo')
-local Tasks = require('milo.taskRunner')
+local Tasks  = require('milo.taskRunner')
+local Util   = require('opus.util')
 
 local ExportTask = {
 	name = 'exporter',
@@ -19,7 +20,6 @@ function ExportTask:cycle(context)
 	for node in context.storage:filterActive('machine', filter) do
 		tasks:add(function()
 			for _, entry in pairs(node.exports) do
-
 				if not entry.filter then
 					-- exports must have a filter
 					-- TODO: validate in exportView

--- a/milo/plugins/exportTask.lua
+++ b/milo/plugins/exportTask.lua
@@ -69,20 +69,21 @@ function ExportTask:cycle(context)
 				end
 
 				local function exportItems()
-					local function isPossible(key)
-						local filterItem = itemDB:get(key)
-
+					local function canExport(item)
 						if not node.adapter.__size then
 							node.adapter.__size = node.adapter.size()
 						end
 
-						-- note that this does not guarantee a match - as
-						-- we don't have full meta of item in slot
+						if not slots then
+							slots = node.adapter.list()
+						end
+
 						for i = 1, node.adapter.__size do
 							local slot = slots[i]
-							if (not slot or slot.name == filterItem.name and
-								(entry.ignoreDamage or slot.damage == filterItem.damage) and
-								slot.count < filterItem.maxCount) then
+							if (not slot or slot.name == item.name and
+								(entry.ignoreDamage or slot.damage == item.damage) and
+								(entry.ignoreNbtHash or slot.nbtHash == item.nbtHash) and
+								slot.count < item.maxCount) then
 
 								return true
 							end
@@ -90,21 +91,14 @@ function ExportTask:cycle(context)
 					end
 
 					for key in pairs(entry.filter) do
-						if not slots then
-							slots = node.adapter.list()
-						end
-						if isPossible(key) then
-							local items = Milo:getMatches(itemDB:splitKey(key), entry)
-							for _,item in pairs(items) do
+						local items = Milo:getMatches(itemDB:splitKey(key), entry)
+						for _,item in pairs(items) do
+							if canExport(item) then
 								if context.storage:export(node, nil, item.count, item) == 0 then
-									-- TODO: really shouldn't break here as there may be room in other slots
-									-- leaving for now for performance reasons
-
 									break
-								else
-									-- refresh the slots
-									slots = nil
 								end
+								-- refresh the slots
+								slots = nil
 							end
 						end
 					end

--- a/milo/plugins/exportTask.lua
+++ b/milo/plugins/exportTask.lua
@@ -66,29 +66,24 @@ function ExportTask:cycle(context)
 				end
 
 				local function exportItems()
-					local debugLog="exportItems()"
 					node.cacheList = node.adapter.list()
 					for key in pairs(entry.filter) do
 						local items = Milo:getMatches(itemDB:splitKey(key), entry)
 						for _,item in pairs(items) do
 							if node.adapter.size() ~= Util.size(node.cacheList) then
-								debugLog=debugLog.." empty slot found"
 								-- Here we have a storage which has at least 1 unpopulated slot, we can fire'n'forget into this
 								if context.storage:export(node, nil, item.count, item) == 0 then
-									debugLog=debugLog.." failed to export, break"
 									-- TODO: really shouldn't break here as there may be room in other slots
 									-- leaving for now for performance reasons
 									break
 								end
 							else
 								-- Here we have a storage with all slots occupied, sort through and find open spaces
-								debugLog=debugLog.." no empty slots found, cycling slots"
 								for iNum,_ in ipairs(node.cacheList) do
 									local slot = node.adapter.getItemMeta(iNum)
 									if (slot.name == filterItem.name and slot.count ~= slot.maxCount and
 									(entry.ignoreDamage or slot.damage == filterItem.damage) and
 									(entry.ignoreNbtHash or slot.nbtHash == filterItem.nbtHash)) then
-										debugLog=debugLog.." found matching slot, exporting"
 										-- We found a slot that matches, and is not full, let's export to it!
 										context.storage:export(node, iNum, math.min(slot.maxCount-slot.count,item.count), item)
 									end
@@ -97,7 +92,6 @@ function ExportTask:cycle(context)
 						end
 					end
 					node.cacheList=nil
-					_G._syslog(debugLog)
 				end
 				if type(entry.slot) == 'number' then
 					exportSingleSlot()

--- a/miloApps/apps/furniController.lua
+++ b/miloApps/apps/furniController.lua
@@ -1,0 +1,184 @@
+-- (Super)MultiFurnace Controller (did I mention, it's SUPER!?)
+-- This app is designed to wrap up to 4 of kepler155c's MultiFurnace (multiFurni) arrays and divide up workload,
+-- it functions as a straight drop-in for furni.lua and no other adjustments are required to make it work.
+-- Additionally, you get the ability to target any one multiFurni array for smelting when creating the machine recipe in Milo
+-- Further uses for this direct targeting can be limited-scope auto-smelting, using anywhere from 1/2 to 1/4 of your total
+-- capacity to auto-smelt, leaving the rest of the cluster available for you when you want it, great for multi-user bases!
+
+-- Plug this turtle into a modem on your Milo network, and another modem leading to 2-4 turtles running furni.lua (or even furniController.lua for chained setups)
+
+-- Slots are as follows:
+-- 1: Master Furnace Input
+-- 2: Master Furnace Fuel Input
+-- 3: Master Furnace Output
+-- 4: Optional (Options: "fuel"/"input"/"output"/"" (Default: "" [ignore]))
+-- 5-8: Furnace Inputs for up to 4 MultiFurnace arrays
+-- 9-12: Furnace Fuels for up to 4 MultiFurnace arrays
+-- 13-16: Furnace Outputs for up to 4 MultiFurnace arrays
+
+-- Only option, slot 4, what to use it for? (Extra) fuel, input, output, [default, ignore]
+useSlot4="" -- default:"" [unused, ignore] (REMEMBER: Map this slot accordingly in Milo!)
+
+--Find modem with -only- turtles attached (these are our furni.lua arrays)
+devModem=""
+for nDev,modem in ipairs({peripheral.find("modem")}) do
+  if #modem.getNamesRemote() > 0 then
+    nTurtles=0
+    for nDev,dev in ipairs(modem.getNamesRemote()) do
+      if modem.getTypeRemote(dev) == "turtle" then nTurtles=nTurtles+1 end
+    end
+    if nTurtles==#modem.getNamesRemote() then
+      devModem=modem
+      break
+    end
+  end
+end
+if devModem ~= "" then
+  print("Found turtle-only modem, detected",#devModem.getNamesRemote(),"turtles",(#devModem.getNamesRemote() > 4 and "(Max 4 will be mapped)" or "(All will be mapped)"))
+end
+devTurtles={}
+for nDev,dev in ipairs(devModem.getNamesRemote()) do
+  if #devTurtles >= 4 then break end
+  devTurtles[#devTurtles+1]=peripheral.wrap(dev)
+  print("Mapping",devTurtles[#devTurtles].getLabel(),"("..dev..")","as device",#devTurtles)
+  devTurtles[#devTurtles].inputSlot=#devTurtles+4 -- Set the input for this device on second row
+  devTurtles[#devTurtles].fuelSlot=#devTurtles+8 -- Set the fuel for this device on third row
+  devTurtles[#devTurtles].outputSlot=#devTurtles+12 -- Set the output for this device on fourth row
+  if devTurtles[#devTurtles].isOn() then
+    print("Resynchronizing",devTurtles[#devTurtles].getLabel())
+    devTurtles[#devTurtles].reboot()
+  else
+    print("Powering",devTurtles[#devTurtles].getLabel(),"on")
+    devTurtles[#devTurtles].turnOn()
+  end
+end
+
+function manageFuel()
+  if turtle.getItemCount(2) > 0 then -- Fuel
+    --print("Fuel found")
+    splitNum=turtle.getItemCount(2)/#devTurtles
+    for nDev,dev in ipairs(devTurtles) do
+      if turtle.select(2) and turtle.getSelectedSlot() == 2 then
+        turtle.transferTo(dev.fuelSlot,splitNum)
+        dev.pullItems(devModem.getNameLocal(),dev.fuelSlot,64,2)
+      end
+    end
+  end
+end
+
+turtle.list = function ()
+  local tList={}
+  for i=1,16 do
+    local slotData=turtle.getItemDetail(i) -- DWGFJTLR
+    if slotData ~= nil then
+      slotData.maxStack=turtle.getItemCount(i) + turtle.getItemSpace(i)
+      tList[i]=slotData
+    end
+  end
+  return tList
+end
+
+function manageLocalResources()
+  --print("Input found")
+  local itemCount=turtle.getItemCount(1)/#devTurtles
+  if itemCount < 1 then itemCount = 1 end -- Patch for single items fed into master slot
+  if turtle.getItemCount(1) > 0 then -- Input
+    for nDev,dev in ipairs(devTurtles) do
+      local devList=dev.list()
+      if turtle.select(1) and ((turtle.compareTo(dev.inputSlot) and turtle.getItemSpace(dev.inputSlot) > 0) or turtle.getItemCount(dev.inputSlot) == 0) then -- Move Input
+        turtle.transferTo(dev.inputSlot,itemCount)
+      end
+      if useSlot4 == "input" and turtle.select(4) and ((turtle.compareTo(dev.inputSlot) and turtle.getItemSpace(dev.inputSlot) > 0) or turtle.getItemCount(dev.inputSlot) == 0) then -- Move Input
+        turtle.transferTo(dev.inputSlot,itemCount)
+      end --Slot 4 input
+    end
+  end
+  if turtle.select(2) and turtle.getSelectedSlot() == 2 then -- Fuel
+    for nDev,dev in ipairs(devTurtles) do
+      local devList=dev.list()
+      if turtle.compareTo(dev.fuelSlot) or turtle.getItemCount(dev.fuelSlot) == 0 then turtle.transferTo(dev.fuelSlot,64) end -- Move fuel into slot
+    end
+  end
+  if useSlot4 == "fuel" and turtle.select(4) and turtle.getSelectedSlot() == 4 then -- Fuel
+    for nDev,dev in ipairs(devTurtles) do
+      local devList=dev.list()
+      if turtle.compareTo(dev.fuelSlot) or turtle.getItemCount(dev.fuelSlot) == 0 then turtle.transferTo(dev.fuelSlot,64) end -- Move fuel into slot
+    end
+  end -- Slot 4 fuel
+
+  for nDev,dev in ipairs(devTurtles) do
+    local devList=dev.list()
+    if turtle.getItemCount(3) == 0 and turtle.getItemCount(dev.outputSlot) > 0 then
+        turtle.select(dev.outputSlot)
+        turtle.transferTo(3,64)
+    elseif turtle.getItemCount(dev.outputSlot) > 0 and turtle.select(3) and turtle.compareTo(dev.outputSlot) then -- Move output
+      --turtle.setStatus("moving")
+      turtle.select(dev.outputSlot)
+      turtle.transferTo(3,64)
+    end
+    if useSlot4 == "output" then -- Slot 4 output
+      if turtle.getItemCount(4) == 0 and turtle.getItemCount(dev.outputSlot) > 0 then
+        turtle.select(dev.outputSlot)
+        turtle.transferTo(4,64)
+      elseif turtle.getItemCount(dev.outputSlot) > 0 and turtle.select(4) and turtle.compareTo(dev.outputSlot) then
+        turtle.select(dev.outputSlot)
+        turtle.transferTo(4,64)
+      end
+    end
+  end
+end
+
+function manageRemoteResources()
+  local localList=turtle.list()
+  for nDev,dev in ipairs(devTurtles) do
+    local devList=dev.list()
+    --print(textutils.serialize(devList))
+    if devList[2] == nil then
+      if localList[dev.fuelSlot] ~= nil then
+        turtle.setStatus("fueling")
+        dev.pullItems(devModem.getNameLocal(),dev.fuelSlot,64,2)
+      end
+    else
+      if localList[dev.fuelSlot] ~= nil and localList[dev.fuelSlot].name == devList[2].name then
+        turtle.setStatus("fueling")
+        dev.pullItems(devModem.getNameLocal(),dev.fuelSlot,64,2)
+      end
+    end
+    if devList[1] == nil then
+      if localList[dev.inputSlot] ~= nil then
+        turtle.setStatus("pushing")
+        dev.pullItems(devModem.getNameLocal(),dev.inputSlot,64,1)
+      end
+    else
+      if localList[dev.inputSlot] ~= nil and localList[dev.inputSlot].name == devList[1].name then
+        turtle.setStatus("pushing")
+        dev.pullItems(devModem.getNameLocal(),dev.inputSlot,64,1)
+      end
+    end -- Move input
+    if devList[3] ~= nil then
+      if localList[dev.outputSlot] == nil then
+        turtle.setStatus("pulling")
+        dev.pushItems(devModem.getNameLocal(),3,64,dev.outputSlot)
+      end
+    else
+      if localList[dev.outputSlot] ~= nil then
+        if devList[3] ~= nil and localList[dev.outputSlot].name == devList[3].name then
+          turtle.setStatus("pulling")
+          dev.pushItems(devModem.getNameLocal(),3,64,dev.outputSlot)
+        end
+      end
+    end
+  end
+end
+
+local lastList={}
+while true do -- Main Loop
+  --manageFuel()
+  local turtleList=turtle.list()
+  if turtleList[1]~=nil or turtleList[13]~=nil or turtleList[14]~=nil or turtleList[15]~=nil or turtleList[16]~=nil then
+    manageLocalResources()
+  end
+  manageRemoteResources()
+  turtle.setStatus("sleeping")
+  os.sleep(1)
+end


### PR DESCRIPTION
Cheap fix to stop cascading storage updates from eating up all the working time available after failing exports, this needs to be fleshed out better, if the chest is full, scan the slots for any that match and are not full, stop blindly exporting.

Added furniController to miloApps, a multi-furnace-array controller, read the header notes for information