### PR TITLE
fix: parallel fix 2

### DIFF
--- a/milo/apis/storage.lua
+++ b/milo/apis/storage.lua
@@ -277,6 +277,10 @@ function Storage:listItems(throttle)
 				chunk = {}
 			end
 		end
+		
+		if #chunk > 0 then
+			parallel.waitForAll(table.unpack(chunk))
+		end
 	end
 
 	for _, adapter in self:onlineAdapters() do


### PR DESCRIPTION
Small extra fix from my last PR - sorry I didn't catch this before. Anything leftover in the chunk wasn't getting ran, including if there was less than 16 storage devices at all. This caused small networks to not scan at all.