### PR TITLE
Fix storageGen.lua, move it out of apps

### DIFF
--- a/milo/autorun/milo.lua
+++ b/milo/autorun/milo.lua
@@ -6,6 +6,7 @@ fs.delete('packages/milo/Milo.lua')
 fs.delete('packages/milo/plugins/listing.lua')
 fs.delete('packages/milo/apis/milo.lua')
 fs.delete('packages/milo/plugins/manipulator.lua')
+fs.delete('packages/milo/apps')
 
 if peripheral.find('workbench') and shell.openForegroundTab then
 	shell.openForegroundTab('MiloLocal')

--- a/milo/storageGen.lua
+++ b/milo/storageGen.lua
@@ -86,7 +86,7 @@ end
 function page:saveConfig(path)
 	local config = Util.readTable(path) or {}
 	Util.each(self.storages, function(dev, name)
-		if self.typeGrid.values[dev.type] and self.typeGrid.values[dev.type].checked and not config[name] then
+		if self.typeGrid.values[dev.type] and self.typeGrid.values[dev.type].checked and (not config[name] or config[name].mtype == 'ignore') then
 			config[name] = {
 				name = name,
 				category = 'storage',


### PR DESCRIPTION
storageGen.lua broke some time ago, since Milo stores non-used nodes in the config with an "ignore" type, so if Milo was ever launched before storageGen.lua, then storageGen.lua wouldn't work. Also, storageGen.lua used to be stored in packages/milo/apps but it seems some shell or package changes have made that no longer in the shell path, so I moved storageGen.lua out of packages/milo/apps.