### PR TITLE
Update k.lua and w.lua

### DIFF
--- a/swshop/apis/k.lua
+++ b/swshop/apis/k.lua
@@ -4,9 +4,9 @@ local jua
 local json
 local await
 
-local endpoint = "krist.ceriat.net"
-local wsEndpoint = "ws://"..endpoint
-local httpEndpoint = "http://"..endpoint
+local endpoint = "krist.dev"
+local wsEndpoint = "wss://"..endpoint
+local httpEndpoint = "https://"..endpoint
 
 local function asserttype(var, name, vartype, optional)
 	if not (type(var) == vartype or optional and type(var) == "nil") then
@@ -53,7 +53,7 @@ local function authorize_websocket(cb, privatekey)
 	asserttype(privatekey, "privatekey", "string", true)
 
 	api_request(function(success, data)
-		cb(success and data and data.ok, data.url and data.url:gsub("wss:", "ws:") or data)
+		cb(success and data and data.ok, data.url and data.url:gsub("ws:", "wss:") or data)
 	end, "/ws/start", {
 		privatekey = privatekey
 	})

--- a/swshop/apis/w.lua
+++ b/swshop/apis/w.lua
@@ -79,10 +79,12 @@ function init(jua)
 
 		jua.on("websocket_failure", function(event, url)
 			local id = findID(url)
-			if id and callbackRegistry[id].failure then
-				callbackRegistry[id].failure(id)
+			if id then
+				if callbackRegistry[id].failure then
+					callbackRegistry[id].failure(id)
+				end
+				table.remove(callbackRegistry, id)
 			end
-			table.remove(callbackRegistry, id)
 		end)
 
 		jua.on("websocket_message", function(event, url, data)
@@ -94,10 +96,12 @@ function init(jua)
 
 		jua.on("websocket_closed", function(event, url)
 			local id = findID(url)
-			if id and callbackRegistry[id].closed then
-				callbackRegistry[id].closed(id)
+			if id then
+				if callbackRegistry[id].closed then
+					callbackRegistry[id].closed(id)
+				end
+				table.remove(callbackRegistry, id)
 			end
-			table.remove(callbackRegistry, id)
 		end)
 	else
 		jua.on("socket_connect", function(event, id)
@@ -107,10 +111,12 @@ function init(jua)
 		end)
 
 		jua.on("socket_error", function(event, id, msg)
-			if id and callbackRegistry[id].failure then
-				callbackRegistry[id].failure(id, msg)
+			if id then
+				if callbackRegistry[id].failure then
+					callbackRegistry[id].failure(id)
+				end
+				table.remove(callbackRegistry, id)
 			end
-			table.remove(callbackRegistry, id)
 		end)
 
 		jua.on("socket_message", function(event, id)
@@ -121,10 +127,12 @@ function init(jua)
 		end)
 
 		jua.on("socket_closed", function(event, id)
-			if id and callbackRegistry[id].closed then
-				callbackRegistry[id].closed(id)
+			if id then
+				if callbackRegistry[id].closed then
+					callbackRegistry[id].closed(id)
+				end
+				table.remove(callbackRegistry, id)
 			end
-			table.remove(callbackRegistry, id)
 		end)
 	end
 end


### PR DESCRIPTION
I had to type in the updated code manually, since for some reason, the version here uses tabs instead of two spaces. Personally I don't like the way that these external libraries are included here - maybe we could do something like urlfs but only download them once instead of every boot - but hopefully we won't need to worry about that when there is an alternative krist library (ETA next century)

(BTW: I was starting work on a few other changes to swshop at https://github.com/kan18/opus-apps/tree/shop-changes , although I am not finished at all with those)